### PR TITLE
Fix a typo

### DIFF
--- a/parts/6.md
+++ b/parts/6.md
@@ -6,7 +6,7 @@ In Lisp one of the fundamental data structures is *the list* (the name Lisp is d
 
 - `cons` is used to construct lists from a "head" element, and the rest of the list (the "tail").
 - `head` extracts the first element of a list
-- `tail` returns the rest of the elments, once the first is dropped.
+- `tail` returns the rest of the elements, once the first is dropped.
 - `empty` takes a list as input, and returns `#t` if it is empty and `#f` otherwise.
 
 Go on then, finish your language.


### PR DESCRIPTION
`elments` → `elements`